### PR TITLE
Implement logging error wrapper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,13 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.4.1
 	github.com/google/go-cmp v0.2.0
 	github.com/jinzhu/gorm v1.9.12
+	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/lib/pq v1.3.0 // indirect
 	github.com/pkg/errors v0.8.0
+	github.com/sirupsen/logrus v1.5.0
 	github.com/spf13/viper v1.6.2
 	github.com/stretchr/testify v1.4.0
-	golang.org/x/sys v0.0.0-20200116001909-b77594299b42 // indirect
+	golang.org/x/sys v0.0.0-20200427175716-29b57079015a // indirect
 	golang.org/x/text v0.3.2 // indirect
 	gopkg.in/yaml.v2 v2.2.8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -68,7 +68,10 @@ github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfV
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
+github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=
+github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -105,6 +108,8 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
+github.com/sirupsen/logrus v1.5.0 h1:1N5EYkVAPEywqZRJd7cwnRtCb6xJx7NH3T3WUTF980Q=
+github.com/sirupsen/logrus v1.5.0/go.mod h1:+F7Ogzej0PZc/94MaYx/nvG9jOFMD2osvC3s+Squfpo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
@@ -163,8 +168,9 @@ golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200116001909-b77594299b42 h1:vEOn+mP2zCOVzKckCZy6YsCtDblrpj/w7B9nxGNELpg=
-golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200427175716-29b57079015a h1:08u6b1caTT9MQY4wSbmsd4Ulm6DmgNYnbImBuZjGJow=
+golang.org/x/sys v0.0.0-20200427175716-29b57079015a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=

--- a/internal/logging/error_wrapper.go
+++ b/internal/logging/error_wrapper.go
@@ -1,0 +1,84 @@
+package logging
+
+import (
+	"errors"
+
+	"github.com/sirupsen/logrus"
+)
+
+// LogError logs an error according to its type.
+//
+// If the error wraps in a `WithLogError` it will use its embedded parameters to log at a specific levels
+// and with specific fields.
+//
+// If the error doesn't wrap `WithLogError` it will log the error on `logrus.ErrorLevel` and simply add the
+// error field.
+func LogError(logger logrus.FieldLogger, err error, message string) {
+	if err == nil {
+		return
+	}
+
+	var (
+		logLevel  = logrus.ErrorLevel
+		logFields = make(logrus.Fields)
+		logErr    = &WithLogError{}
+	)
+
+	if errors.As(err, &logErr) {
+		logLevel = logErr.LogLevel
+		logFields = logErr.ExtraFields
+	}
+	logger.WithFields(logFields).WithField("error", err.Error()).Logf(logLevel, "%s: %v\n", message, err)
+	if logLevel == logrus.FatalLevel {
+		logrus.Exit(1)
+	}
+}
+
+// WithLog wraps the passed error into a `WithLogError` with the given level and fields.
+//
+// If the err is already a `WithLogError`, it will simply merge the contextual fields. Conflicting contextual
+// fields will be overwritten.
+func WithLog(err error, logLevel logrus.Level, logFields logrus.Fields) error {
+	logErr := &WithLogError{}
+
+	if err == nil {
+		return nil
+	}
+
+	if logFields == nil {
+		logFields = make(logrus.Fields)
+	}
+
+	if errors.As(err, &logErr) {
+		for key, value := range logFields {
+			logErr.ExtraFields[key] = value
+		}
+		return err
+	}
+
+	return &WithLogError{
+		LogLevel:    logLevel,
+		ExtraFields: logFields,
+		err:         err,
+	}
+}
+
+// WithLogError allows to store log information in the returned error.
+type WithLogError struct {
+	LogLevel    logrus.Level
+	ExtraFields logrus.Fields
+
+	err error
+}
+
+// Unwrap returns the underlying error.
+//
+// It implements the `errors.Wrapper` interface.
+func (err *WithLogError) Unwrap() error {
+	return err.err
+}
+
+// Returns the underlying error's string representation.
+func (err *WithLogError) Error() string {
+	return err.err.Error()
+}

--- a/internal/logging/error_wrapper_test.go
+++ b/internal/logging/error_wrapper_test.go
@@ -1,0 +1,140 @@
+package logging
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLogError(t *testing.T) {
+
+	logger, hook := test.NewNullLogger()
+	expectedError := errors.New("testing error")
+	expectedMessage := "message"
+	expectedLogLevel := logrus.ErrorLevel
+	expectedFields := logrus.Fields{
+		"error": expectedError.Error(),
+	}
+
+	assertExpectations := func(t *testing.T) {
+		entry := hook.LastEntry()
+		assert.Equal(t, expectedLogLevel, entry.Level)
+		assert.Equal(t, fmt.Sprintf("%s: %v\n", expectedMessage, expectedError), entry.Message)
+
+		for key, expectedValue := range expectedFields {
+			value, ok := entry.Data[key]
+			if assert.True(t, ok) {
+				assert.Equal(t, expectedValue, value)
+			}
+		}
+
+	}
+
+	t.Run("NilError", func(t *testing.T) {
+		hook.Reset()
+
+		LogError(logger, nil, expectedMessage)
+		assert.Empty(t, hook.AllEntries())
+	})
+
+	t.Run("SimpleError", func(t *testing.T) {
+		hook.Reset()
+
+		LogError(logger, expectedError, expectedMessage)
+		assertExpectations(t)
+	})
+
+	t.Run("WithLogError", func(t *testing.T) {
+		hook.Reset()
+
+		expectedLogLevel = logrus.WarnLevel
+		expectedFields = logrus.Fields{
+			"error": expectedError.Error(),
+			"key":   "value",
+		}
+		expectedError = &WithLogError{
+			LogLevel:    expectedLogLevel,
+			ExtraFields: expectedFields,
+			err:         expectedError,
+		}
+
+		LogError(logger, expectedError, expectedMessage)
+		assertExpectations(t)
+	})
+}
+
+func TestWithLogError(t *testing.T) {
+
+	require.Implements(t, (*error)(nil), &WithLogError{})
+
+	t.Run("NilWrap", func(t *testing.T) {
+		expectedError := error(nil)
+		expectedLogLevel := logrus.WarnLevel
+		expectedFields := logrus.Fields{
+			"key": "value",
+		}
+
+		err := WithLog(expectedError, expectedLogLevel, expectedFields)
+
+		assert.Nil(t, err)
+	})
+
+	t.Run("NoFieldWrap", func(t *testing.T) {
+		expectedError := errors.New("testing error")
+		expectedLogLevel := logrus.WarnLevel
+		expectedFields := logrus.Fields{}
+
+		err := WithLog(expectedError, expectedLogLevel, nil)
+
+		assert.Equal(t, expectedError, err.(*WithLogError).err)
+		assert.Equal(t, expectedError, errors.Unwrap(err))
+		assert.Equal(t, expectedError.Error(), err.Error())
+		assert.Equal(t, expectedLogLevel, err.(*WithLogError).LogLevel)
+		assert.Equal(t, expectedFields, err.(*WithLogError).ExtraFields)
+	})
+
+	t.Run("SimpleWrap", func(t *testing.T) {
+		expectedError := errors.New("testing error")
+		expectedLogLevel := logrus.WarnLevel
+		expectedFields := logrus.Fields{
+			"key": "value",
+		}
+
+		err := WithLog(expectedError, expectedLogLevel, expectedFields)
+
+		assert.Equal(t, expectedError, err.(*WithLogError).err)
+		assert.Equal(t, expectedError, errors.Unwrap(err))
+		assert.Equal(t, expectedError.Error(), err.Error())
+		assert.Equal(t, expectedLogLevel, err.(*WithLogError).LogLevel)
+		assert.Equal(t, expectedFields, err.(*WithLogError).ExtraFields)
+	})
+
+	t.Run("DoubleWrap", func(t *testing.T) {
+		expectedError := errors.New("testing error")
+		expectedLogLevel := logrus.WarnLevel
+		expectedFields := logrus.Fields{
+			"key": "value",
+		}
+
+		err := WithLog(expectedError, expectedLogLevel, expectedFields)
+
+		expectedFields = logrus.Fields{
+			"key":      "newvalue",
+			"otherkey": "othervalue",
+		}
+
+		err = WithLog(err, logrus.DebugLevel, expectedFields)
+
+		assert.Equal(t, expectedError, err.(*WithLogError).err)
+		assert.Equal(t, expectedError, errors.Unwrap(err))
+		assert.Equal(t, expectedError.Error(), err.Error())
+		assert.Equal(t, expectedLogLevel, err.(*WithLogError).LogLevel)
+		assert.Equal(t, expectedFields, err.(*WithLogError).ExtraFields)
+	})
+
+}


### PR DESCRIPTION
Add logging package that could be used to implement Sentry/Logstash init.

Add error wrapper inside the logging package to embed logging info inside errors.