### PR TITLE
Improve logging in daemon service

### DIFF
--- a/cmd/daemon/daemon.go
+++ b/cmd/daemon/daemon.go
@@ -19,11 +19,11 @@ import (
 
 func init() {
 	if err := config.Initiate(); err != nil {
-		logrus.Fatalf("could not load configuration: %v", err)
+		logrus.WithError(err).Fatalf("could not load configuration: %v", err)
 	}
 	logging.Initiate()
 	if err := db.Init(); err != nil {
-		logrus.Fatalf("could not connect to the db: %v", err)
+		logrus.WithError(err).Fatalf("could not connect to the db: %v", err)
 	}
 }
 
@@ -31,12 +31,12 @@ func main() {
 
 	iClient, err := intra.NewClient(config.Conf.Intra.AppID, config.Conf.Intra.AppSecret, http.DefaultClient)
 	if err != nil {
-		logrus.Fatalf("could not initiate intra api client: %v", err)
+		logrus.WithError(err).Fatalf("could not initiate intra api client: %v", err)
 	}
 
 	sClient, err := slack.New(iClient, config.Conf.SlackThat.URL)
 	if err != nil {
-		logrus.Fatalf("could not initiate slack_that client: %v", err)
+		logrus.WithError(err).Fatalf("could not initiate slack_that client: %v", err)
 	}
 
 	tHdl := tasks.NewTasksHandler(sClient, db.GlobalDB)
@@ -47,7 +47,7 @@ func main() {
 
 	scheduler, err := scheduler.New([]scheduler.Task{tasks})
 	if err != nil {
-		logrus.Fatalf("could not create scheduler: %v", err)
+		logrus.WithError(err).Fatalf("could not create scheduler: %v", err)
 	}
 
 	waitForShutdown(scheduler)

--- a/internal/slack/notification.go
+++ b/internal/slack/notification.go
@@ -4,23 +4,31 @@ import (
 	"context"
 	"fmt"
 	"strings"
+
+	"github.com/gustavobelfort/42-jitsi/internal/logging"
+	"github.com/sirupsen/logrus"
 )
 
 // SendNotification sends a notification to multiple users containing a link to a meet.jit.si server
 func (client *ThatClient) SendNotification(scaleTeamID int, logins []string) error {
 
+	logrus.WithField("scale_team_id", scaleTeamID).Info("getting scale team users' emails")
 	userEmails, err := client.getUserEmails(logins)
-
 	roomName := formatRoomName(scaleTeamID, logins)
+	ctxfields := logrus.Fields{
+		"scale_team_id": scaleTeamID,
+		"room_name":     roomName,
+	}
 	if err != nil {
-		return err
+		return logging.WithLog(err, logrus.ErrorLevel, ctxfields)
 	}
 
+	logrus.WithFields(ctxfields).Info("posting message to slack_that")
 	if err := client.postMessage(
 		PostMessageUserEmailsOption(userEmails),
 		PostMessageLinkOption(roomName),
 	); err != nil {
-		return err
+		return logging.WithLog(err, logrus.ErrorLevel, ctxfields)
 	}
 
 	return nil


### PR DESCRIPTION
I modified the logging in so that it cares useful informations along with the logging (for example the ID of the scale team it is treating)
I also passed the regular log `getting notifiable scale teams`. This log is important to debug, but really just pollutes your logging files and your ELK.
However I passed the log `found %d scale teams to notify` to info as this might be useful while looking at ELK logs, to see if somehow something is missing.

While doing this I replaced the tasks `return`s to `continue`s. When an error occurs with a scale team it might not occur with the next scale teams. You don't want one scale team to prevent the others to be notified.